### PR TITLE
feat: get binded terminals for integrations API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ go get github.com/PChaparro/bold-co-sdk
 
 Refer to the integration tests to learn how to use the SDK. The available tests by functionality are:
 
-| Feature                               | Integration Test File                                                                                           |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Get payment methods for payment link  | [get_payment_methods_for_payment_link_test.go](src/sdk/get_payment_methods_for_payment_link_test.go)            |
-| Create payment link                   | [create_payment_link_test.go](src/sdk/create_payment_link_test.go)                                              |
-| Get payment link                      | [get_payment_link_data_test.go](src/sdk/get_payment_link_data_test.go)                                          |
-| Get payment methods for integration   | [get_payment_methods_for_integrations_api_test.go](src/sdk/get_payment_methods_for_integrations_api_test.go)    |
-| Get payment terminals for integration | [get_payment_terminals_for_integrations_api_test.go](src/sdk/get_binded_terminals_for_integrations_api_test.go) |
+| Feature                               | Integration Test File                                                                                          |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Get payment methods for payment link  | [get_payment_methods_for_payment_link_test.go](src/sdk/get_payment_methods_for_payment_link_test.go)           |
+| Create payment link                   | [create_payment_link_test.go](src/sdk/create_payment_link_test.go)                                             |
+| Get payment link                      | [get_payment_link_data_test.go](src/sdk/get_payment_link_data_test.go)                                         |
+| Get payment methods for integration   | [get_payment_methods_for_integrations_api_test.go](src/sdk/get_payment_methods_for_integrations_api_test.go)   |
+| Get payment terminals for integration | [get_binded_terminals_for_integrations_api_test.go](src/sdk/get_binded_terminals_for_integrations_api_test.go) |
 
 Below is an example of generating a payment link:
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Programmatically generate payment links for e-commerce and SaaS platforms, enabl
 
 Facilitates direct communication between applications and Bold payment terminals (point-of-sale devices), automating the checkout process without manual intervention.
 
-- [x] Retrieve available payment methods ✅
-- [ ] Retrieve available payment terminals (POS devices) ❌
+- [x] Retrieve available payment methods ✅ (Beta, **not fully tested**)
+- [x] Retrieve available payment terminals (POS devices) ✅ (Beta, **not fully tested**)
 - [ ] Create ❌
+
+Please note that the **integrations API is currently in beta**, which means it may undergo changes. Likewise, the implementation in this repository for interacting with the integrations API is also in beta, as testing these endpoints requires a physical payment terminal. **The current implementation is based solely on the examples provided in the official documentation, and full testing has not been possible due to the lack of access to a physical device.**
 
 ## Installation 📦
 
@@ -40,12 +42,13 @@ go get github.com/PChaparro/bold-co-sdk
 
 Refer to the integration tests to learn how to use the SDK. The available tests by functionality are:
 
-| Feature                              | Integration Test File                                                                                        |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| Get payment methods for payment link | [get_payment_methods_for_payment_link_test.go](src/sdk/get_payment_methods_for_payment_link_test.go)         |
-| Create payment link                  | [create_payment_link_test.go](src/sdk/create_payment_link_test.go)                                           |
-| Get payment link                     | [get_payment_link_data_test.go](src/sdk/get_payment_link_data_test.go)                                       |
-| Get payment methods for integration  | [get_payment_methods_for_integrations_api_test.go](src/sdk/get_payment_methods_for_integrations_api_test.go) |
+| Feature                               | Integration Test File                                                                                           |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Get payment methods for payment link  | [get_payment_methods_for_payment_link_test.go](src/sdk/get_payment_methods_for_payment_link_test.go)            |
+| Create payment link                   | [create_payment_link_test.go](src/sdk/create_payment_link_test.go)                                              |
+| Get payment link                      | [get_payment_link_data_test.go](src/sdk/get_payment_link_data_test.go)                                          |
+| Get payment methods for integration   | [get_payment_methods_for_integrations_api_test.go](src/sdk/get_payment_methods_for_integrations_api_test.go)    |
+| Get payment terminals for integration | [get_payment_terminals_for_integrations_api_test.go](src/sdk/get_binded_terminals_for_integrations_api_test.go) |
 
 Below is an example of generating a payment link:
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -20,9 +20,11 @@ Genera enlaces de pago de forma programática para comercios electrónicos y apl
 
 Permite la comunicación directa entre aplicaciones y terminales de pago (datáfonos) de Bold, automatizando el proceso de cobro sin intervención manual.
 
-- [x] Consultar métodos de pago disponibles ✅
-- [ ] Consultar terminales de pago (datáfonos) disponibles ❌
+- [x] Consultar métodos de pago disponibles ✅ (Beta, **no fue probado por completo**)
+- [x] Consultar terminales de pago (datáfonos) disponibles ✅ (Beta, **no fue probado por completo**)
 - [ ] Crear pagos ❌
+
+Ten en cuenta que **la API de integraciones se encuentra actualmente en fase beta**, lo que significa que puede estar sujeta a cambios. De igual manera, la implementación presente en este repositorio para interactuar con la API de integraciones también está en fase beta, ya que probar estos endpoints requiere una terminal de pago física. **La implementación actual se basa únicamente en los ejemplos provistos por la documentación oficial, y no ha sido posible realizar pruebas completas debido a la falta de acceso a un dispositivo físico.**
 
 ## Instalación 📦
 
@@ -36,12 +38,13 @@ go get github.com/PChaparro/bold-co-sdk
 
 Puedes guiarte por los tests de integración para aprender a usar el SDK. A continuación, los tests disponibles por funcionalidad:
 
-| Funcionalidad                                | Tests de integración                                                                                                    |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Consultar métodos de pago para link de pago  | [get_payment_methods_test.go](.././../../src/sdk/get_payment_methods_test.go)                                           |
-| Crear link de pago                           | [create_payment_link_test.go](.././../../src/sdk/create_payment_link_test.go)                                           |
-| Consultar link de pago                       | [get_payment_link_data_test.go](.././../../src/sdk/get_payment_link_data_test.go)                                       |
-| Consultar métodos de pago para integraciones | [get_payment_methods_for_integrations_api_test.go](.././../../src/sdk/get_payment_methods_for_integrations_api_test.go) |
+| Funcionalidad                                   | Tests de integración                                                                                                       |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Consultar métodos de pago para link de pago     | [get_payment_methods_test.go](.././../../src/sdk/get_payment_methods_test.go)                                              |
+| Crear link de pago                              | [create_payment_link_test.go](.././../../src/sdk/create_payment_link_test.go)                                              |
+| Consultar link de pago                          | [get_payment_link_data_test.go](.././../../src/sdk/get_payment_link_data_test.go)                                          |
+| Consultar métodos de pago para integraciones    | [get_payment_methods_for_integrations_api_test.go](.././../../src/sdk/get_payment_methods_for_integrations_api_test.go)    |
+| Consultar terminales de pago para integraciones | [get_payment_terminals_for_integrations_api_test.go](.././../../src/sdk/get_binded_terminals_for_integrations_api_test.go) |
 
 A modo de ejemplo, para generar un enlace de pago, puedes usar el siguiente fragmento de código:
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -38,13 +38,13 @@ go get github.com/PChaparro/bold-co-sdk
 
 Puedes guiarte por los tests de integración para aprender a usar el SDK. A continuación, los tests disponibles por funcionalidad:
 
-| Funcionalidad                                   | Tests de integración                                                                                                       |
-| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| Consultar métodos de pago para link de pago     | [get_payment_methods_test.go](.././../../src/sdk/get_payment_methods_test.go)                                              |
-| Crear link de pago                              | [create_payment_link_test.go](.././../../src/sdk/create_payment_link_test.go)                                              |
-| Consultar link de pago                          | [get_payment_link_data_test.go](.././../../src/sdk/get_payment_link_data_test.go)                                          |
-| Consultar métodos de pago para integraciones    | [get_payment_methods_for_integrations_api_test.go](.././../../src/sdk/get_payment_methods_for_integrations_api_test.go)    |
-| Consultar terminales de pago para integraciones | [get_payment_terminals_for_integrations_api_test.go](.././../../src/sdk/get_binded_terminals_for_integrations_api_test.go) |
+| Funcionalidad                                   | Tests de integración                                                                                                      |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Consultar métodos de pago para link de pago     | [get_payment_methods_test.go](.././../../src/sdk/get_payment_methods_test.go)                                             |
+| Crear link de pago                              | [create_payment_link_test.go](.././../../src/sdk/create_payment_link_test.go)                                             |
+| Consultar link de pago                          | [get_payment_link_data_test.go](.././../../src/sdk/get_payment_link_data_test.go)                                         |
+| Consultar métodos de pago para integraciones    | [get_payment_methods_for_integrations_api_test.go](.././../../src/sdk/get_payment_methods_for_integrations_api_test.go)   |
+| Consultar terminales de pago para integraciones | [get_binded_terminals_for_integrations_api_test.go](.././../../src/sdk/get_binded_terminals_for_integrations_api_test.go) |
 
 A modo de ejemplo, para generar un enlace de pago, puedes usar el siguiente fragmento de código:
 

--- a/src/definitions/get_binded_terminals_for_integrations_api_response.go
+++ b/src/definitions/get_binded_terminals_for_integrations_api_response.go
@@ -1,0 +1,31 @@
+package definitions
+
+// GetBindedTerminalsForIntegrationsAPIResponse represents the API response
+// for retrieving available terminals for integration.
+type GetBindedTerminalsForIntegrationsAPIResponse struct {
+	// Payload contains the information of the available terminals.
+	Payload GetBindedTerminalsPayload `json:"payload"`
+	// Errors contains any errors that occurred during the request.
+	Errors []ErrorField `json:"errors,omitempty"`
+}
+
+// GetBindedTerminalsPayload contains the information of available terminals.
+type GetBindedTerminalsPayload struct {
+	AvailableTerminals *[]TerminalInfo `json:"available_terminals,omitempty"`
+}
+
+// TerminalInfo contains the information of a specific terminal.
+type TerminalInfo struct {
+	TerminalModel  string         `json:"terminal_model"`
+	TerminalSerial string         `json:"terminal_serial"`
+	Status         TerminalStatus `json:"status"`
+	Name           string         `json:"name"`
+}
+
+// TerminalStatus constants for the status of the terminals.
+type TerminalStatus string
+
+const (
+	// TerminalStatusBinded represents a terminal binded to the integration.
+	TerminalStatusBinded TerminalStatus = "BINDED"
+)

--- a/src/sdk/create_payment_link_test.go
+++ b/src/sdk/create_payment_link_test.go
@@ -25,7 +25,7 @@ func TestCreatePaymentLink(t *testing.T) {
 	})
 
 	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	t.Run("successful payment link creation", func(t *testing.T) {

--- a/src/sdk/get_binded_terminals_for_integrations_api.go
+++ b/src/sdk/get_binded_terminals_for_integrations_api.go
@@ -1,0 +1,20 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/PChaparro/bold-co-sdk/src/definitions"
+)
+
+// GetBindedTerminalsForIntegrationsAPI retrieves the binded terminals
+// that can be used with the integrations API.
+func (client *BoldClient) GetBindedTerminalsForIntegrationsAPI(ctx context.Context) (*definitions.GetBindedTerminalsForIntegrationsAPIResponse, error) {
+	return sendGETRequest[definitions.GetBindedTerminalsForIntegrationsAPIResponse](
+		client,
+		ctx,
+		RequestParams{
+			Endpoint: "/payments/binded-terminals",
+			Action:   "get binded terminals for integrations API",
+		},
+	)
+}

--- a/src/sdk/get_binded_terminals_for_integrations_api_test.go
+++ b/src/sdk/get_binded_terminals_for_integrations_api_test.go
@@ -23,7 +23,7 @@ func TestGetBindedTerminalsForIntegrationsAPI(t *testing.T) {
 	})
 
 	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Due to the absence of a payment terminal, the API does not return

--- a/src/sdk/get_binded_terminals_for_integrations_api_test.go
+++ b/src/sdk/get_binded_terminals_for_integrations_api_test.go
@@ -1,0 +1,72 @@
+package sdk
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBindedTerminalsForIntegrationsAPI(t *testing.T) {
+	// Get API key from environment variable
+	apiKey := os.Getenv("BOLD_API_KEY")
+	if apiKey == "" {
+		t.Skip("BOLD_API_KEY environment variable not set")
+	}
+
+	// Initialize the client
+	client := NewClient(ClientConfig{
+		ApiKey: apiKey,
+	})
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Due to the absence of a payment terminal, the API does not return
+	// an empty array but instead returns a 404 error, indicating that no
+	// payment terminals were found. If a payment terminal were available,
+	// the following code should be used to validate the response.
+	/* t.Run("successful binded terminals retrieval", func(t *testing.T) {
+		// Make the request
+		response, err := client.GetBindedTerminalsForIntegrationsAPI(ctx)
+
+		// Assert response
+		require.NoError(t, err)
+		require.NotNil(t, response)
+
+		// Check the payload
+		assert.NotNil(t, response.Payload)
+
+		// If the available terminals array is not nil, validate its structure
+		if response.Payload.AvailableTerminals != nil {
+			assert.NotEmpty(t, *response.Payload.AvailableTerminals, "Available terminals should not be empty")
+
+			// If there are any terminals returned, validate their structure
+			for _, terminal := range *response.Payload.AvailableTerminals {
+				assert.NotEmpty(t, terminal.TerminalModel, "Terminal model should not be empty")
+				assert.NotEmpty(t, terminal.TerminalSerial, "Terminal serial should not be empty")
+				assert.NotEmpty(t, terminal.Name, "Terminal name should not be empty")
+				assert.NotEmpty(t, string(terminal.Status), "Terminal status should not be empty")
+			}
+		}
+
+		// Check for empty errors list
+		assert.Empty(t, response.Errors)
+	}) */
+
+	// Workaround for the absence of a payment .
+	// The API does not return an empty array but instead returns a 404 error,
+	t.Run("available terminals not found", func(t *testing.T) {
+		// Make the request
+		response, err := client.GetBindedTerminalsForIntegrationsAPI(ctx)
+
+		// Assert response
+		require.Error(t, err)
+		require.Nil(t, response)
+		assert.Contains(t, err.Error(), "Available terminals not found", "Error message should contain 'Available terminals not found'")
+	})
+}

--- a/src/sdk/get_payment_link_data_test.go
+++ b/src/sdk/get_payment_link_data_test.go
@@ -25,7 +25,7 @@ func TestGetPaymentLinkData(t *testing.T) {
 	})
 
 	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	t.Run("successful payment link data retrieval", func(t *testing.T) {

--- a/src/sdk/get_payment_methods_for_integrations_api_test.go
+++ b/src/sdk/get_payment_methods_for_integrations_api_test.go
@@ -23,7 +23,7 @@ func TestGetPaymentMethodsForIntegrationsAPI(t *testing.T) {
 	})
 
 	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	t.Run("successful payment methods retrieval", func(t *testing.T) {

--- a/src/sdk/get_payment_methods_for_payment_link_test.go
+++ b/src/sdk/get_payment_methods_for_payment_link_test.go
@@ -23,7 +23,7 @@ func TestGetPaymentMethodsForPaymentLink(t *testing.T) {
 	})
 
 	// Create context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	t.Run("successful payment methods retrieval", func(t *testing.T) {


### PR DESCRIPTION
## Change Description

This pull request adds a new method to retrieve available payment terminals that can be used with the Integrations API.

## API Documentation

- [Consulta de terminales de pago disponibles](https://developers.bold.co/api-integrations/integration#5-consulta-de-terminales-de-pago-disponibles)

## Testing

Due to hardware requirements, the implementation could not be fully tested in a real-world environment, as it requires access to a physical payment terminal. However, the logic was implemented based on the official documentation and reference examples provided by Bold.

## Checklist

- [x] I have read and followed the contribution guidelines described in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.

## Additional Context

While it wasn't possible to test the full end-to-end behavior, the structure and request formatting align with the documented API contracts.

## Related Issues

Not applicable.
