### PR TITLE
feat: create payment using integrations API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Facilitates direct communication between applications and Bold payment terminals
 
 - [x] Retrieve available payment methods ✅ (Beta, **not fully tested**)
 - [x] Retrieve available payment terminals (POS devices) ✅ (Beta, **not fully tested**)
-- [ ] Create ❌
+- [x] Create payment ✅ (Beta, **not fully tested**)
 
 Please note that the **integrations API is currently in beta**, which means it may undergo changes. Likewise, the implementation in this repository for interacting with the integrations API is also in beta, as testing these endpoints requires a physical payment terminal. **The current implementation is based solely on the examples provided in the official documentation, and full testing has not been possible due to the lack of access to a physical device.**
 
@@ -49,6 +49,7 @@ Refer to the integration tests to learn how to use the SDK. The available tests 
 | Get payment link                      | [get_payment_link_data_test.go](src/sdk/get_payment_link_data_test.go)                                         |
 | Get payment methods for integration   | [get_payment_methods_for_integrations_api_test.go](src/sdk/get_payment_methods_for_integrations_api_test.go)   |
 | Get payment terminals for integration | [get_binded_terminals_for_integrations_api_test.go](src/sdk/get_binded_terminals_for_integrations_api_test.go) |
+| Create payment for integration        | [create_payment_for_integrations_api_test.go](src/sdk/create_payment_for_integrations_api_test.go)             |
 
 Below is an example of generating a payment link:
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -22,7 +22,7 @@ Permite la comunicación directa entre aplicaciones y terminales de pago (datáf
 
 - [x] Consultar métodos de pago disponibles ✅ (Beta, **no fue probado por completo**)
 - [x] Consultar terminales de pago (datáfonos) disponibles ✅ (Beta, **no fue probado por completo**)
-- [ ] Crear pagos ❌
+- [x] Crear pago ✅ (Beta, **no fue probado por completo**)
 
 Ten en cuenta que **la API de integraciones se encuentra actualmente en fase beta**, lo que significa que puede estar sujeta a cambios. De igual manera, la implementación presente en este repositorio para interactuar con la API de integraciones también está en fase beta, ya que probar estos endpoints requiere una terminal de pago física. **La implementación actual se basa únicamente en los ejemplos provistos por la documentación oficial, y no ha sido posible realizar pruebas completas debido a la falta de acceso a un dispositivo físico.**
 
@@ -45,6 +45,7 @@ Puedes guiarte por los tests de integración para aprender a usar el SDK. A cont
 | Consultar link de pago                          | [get_payment_link_data_test.go](.././../../src/sdk/get_payment_link_data_test.go)                                         |
 | Consultar métodos de pago para integraciones    | [get_payment_methods_for_integrations_api_test.go](.././../../src/sdk/get_payment_methods_for_integrations_api_test.go)   |
 | Consultar terminales de pago para integraciones | [get_binded_terminals_for_integrations_api_test.go](.././../../src/sdk/get_binded_terminals_for_integrations_api_test.go) |
+| Crear pago para integraciones                   | [create_payment_for_integrations_api_test.go](.././../../src/sdk/create_payment_for_integrations_api_test.go)             |
 
 A modo de ejemplo, para generar un enlace de pago, puedes usar el siguiente fragmento de código:
 

--- a/src/definitions/create_payment_for_integrations_api_request.go
+++ b/src/definitions/create_payment_for_integrations_api_request.go
@@ -1,0 +1,34 @@
+package definitions
+
+// IntegrationAmount represents the payment amount details for the integration API
+type IntegrationAmount struct {
+	Currency    CurrencyType `json:"currency"`        // Currency for the transaction (e.g., COP)
+	Taxes       []Tax        `json:"taxes,omitempty"` // List of taxes applied to the transaction
+	TipAmount   float64      `json:"tip_amount"`      // Optional: Tip amount included in the transaction
+	TotalAmount float64      `json:"total_amount"`    // Total transaction amount including taxes and tips
+}
+
+// PayerDocument represents the identification document of the payer for integration API
+type IntegrationPayerDocument struct {
+	DocumentType   DocumentType `json:"document_type"`   // Type of ID document (e.g., CEDULA, NIT, etc.)
+	DocumentNumber string       `json:"document_number"` // ID document number (4-15 characters)
+}
+
+// IntegrationPayer represents the person making the payment in integration API
+type IntegrationPayer struct {
+	Email       string                    `json:"email,omitempty"`        // Payer's email address
+	PhoneNumber string                    `json:"phone_number,omitempty"` // Payer's phone number
+	Document    *IntegrationPayerDocument `json:"document,omitempty"`     // Payer's identification document
+}
+
+// CreatePaymentForIntegrationsAPIRequest represents a payment request to the Bold Integration API
+type CreatePaymentForIntegrationsAPIRequest struct {
+	Amount         IntegrationAmount `json:"amount"`                // Required: Contains detailed information about the amounts to be processed
+	UserEmail      string            `json:"user_email"`            // Required: Email of the person making the sale
+	PaymentMethod  PaymentMethod     `json:"payment_method"`        // Required: Payment method (POS, NEQUI, DAVIPLATA, PAY_BY_LINK, or empty string)
+	TerminalModel  string            `json:"terminal_model"`        // Required: Model of the terminal to process the payment
+	TerminalSerial string            `json:"terminal_serial"`       // Required: Serial of the terminal to process the payment
+	Reference      string            `json:"reference"`             // Required: Reference to identify the payment in the Webhook response
+	Description    string            `json:"description,omitempty"` // Optional: Brief description of the transaction
+	Payer          *IntegrationPayer `json:"payer,omitempty"`       // Optional: Object specifying the payer's details if needed
+}

--- a/src/definitions/create_payment_for_integrations_api_response.go
+++ b/src/definitions/create_payment_for_integrations_api_response.go
@@ -1,0 +1,17 @@
+package definitions
+
+// IntegrationPaymentData represents the information of a created integration payment.
+type IntegrationPaymentData struct {
+	// IntegrationID is the unique identifier of the created payment integration.
+	IntegrationID string `json:"integration_id"`
+}
+
+// CreatePaymentForIntegrationsAPIResponse represents the response from creating
+// a payment using the integrations API.
+type CreatePaymentForIntegrationsAPIResponse struct {
+	// Payload contains the payment integration details.
+	Payload IntegrationPaymentData `json:"payload"`
+
+	// Errors contains any errors that occurred during the request.
+	Errors []ErrorField `json:"errors,omitempty"`
+}

--- a/src/definitions/create_payment_link_request.go
+++ b/src/definitions/create_payment_link_request.go
@@ -10,10 +10,10 @@ const (
 
 // Amount represents the payment amount details
 type Amount struct {
-	Currency    CurrencyType `json:"currency"`             // Currency for the transaction (COP or USD, will be processed in COP).
-	Taxes       []Tax        `json:"taxes,omitempty"`      // Optional: List of taxes applied to the transaction (VAT or CONSUMPTION).
-	TipAmount   float64      `json:"tip_amount,omitempty"` // Optional: Tip amount included in the transaction.
-	TotalAmount float64      `json:"total_amount"`         // Total transaction amount including taxes and tips.
+	Currency    CurrencyType `json:"currency"`        // Currency for the transaction (COP or USD, will be processed in COP).
+	Taxes       []Tax        `json:"taxes,omitempty"` // Optional: List of taxes applied to the transaction (VAT or CONSUMPTION).
+	TipAmount   float64      `json:"tip_amount"`      // Optional: Tip amount included in the transaction.
+	TotalAmount float64      `json:"total_amount"`    // Total transaction amount including taxes and tips.
 }
 
 // CreatePaymentLinkRequest represents a payment request to the Bold API

--- a/src/definitions/create_payment_link_response.go
+++ b/src/definitions/create_payment_link_response.go
@@ -15,6 +15,5 @@ type CreatePaymentLinkResponse struct {
 	Payload PaymentLinkData `json:"payload"`
 
 	// Errors contains any errors that occurred during the request.
-	// Each error is a map of field name to error message.
 	Errors []ErrorField `json:"errors"`
 }

--- a/src/definitions/get_payment_link_data_response.go
+++ b/src/definitions/get_payment_link_data_response.go
@@ -68,8 +68,5 @@ type GetPaymentLinkDataResponse struct {
 	PaymentLinkDetails
 
 	// Errors contains any errors that occurred during the request.
-	// Each error is a map of field name to error message.
-	// This field is not included in the example response but added for consistency
-	// with other responses in the SDK.
 	Errors []ErrorField `json:"errors,omitempty"`
 }

--- a/src/definitions/get_payment_methods_for_integrations_api_response.go
+++ b/src/definitions/get_payment_methods_for_integrations_api_response.go
@@ -23,6 +23,5 @@ type GetPaymentMethodsForIntegrationsAPIResponse struct {
 	Payload IntegrationPaymentMethodsData `json:"payload"`
 
 	// Errors contains any errors that occurred during the request.
-	// Each error is a map of field name to error message.
 	Errors []ErrorField `json:"errors,omitempty"`
 }

--- a/src/definitions/get_payment_methods_for_payment_link_response.go
+++ b/src/definitions/get_payment_methods_for_payment_link_response.go
@@ -24,6 +24,5 @@ type GetPaymentMethodsForPaymentLinkResponse struct {
 	Payload PaymentMethodsData `json:"payload"`
 
 	// Errors contains any errors that occurred during the request.
-	// Each error is a map of field name to error message.
 	Errors []ErrorField `json:"errors"`
 }

--- a/src/internal/tests/get_payload_to_create_valid_payment_for_integrations_api.go
+++ b/src/internal/tests/get_payload_to_create_valid_payment_for_integrations_api.go
@@ -1,0 +1,38 @@
+package tests
+
+import (
+	"github.com/PChaparro/bold-co-sdk/src/definitions"
+)
+
+// GetPayloadToCreateValidPaymentForIntegrationsAPI returns a valid request to create a payment
+// using the Bold integrations API for testing purposes.
+func GetPayloadToCreateValidPaymentForIntegrationsAPI() *definitions.CreatePaymentForIntegrationsAPIRequest {
+	return &definitions.CreatePaymentForIntegrationsAPIRequest{
+		Amount: definitions.IntegrationAmount{
+			Currency: definitions.CurrencyTypeCOP,
+			Taxes: []definitions.Tax{
+				{
+					Type:  definitions.TaxTypeIVA,
+					Base:  10000,
+					Value: 1000,
+				},
+			},
+			TipAmount:   0,
+			TotalAmount: 1230000,
+		},
+		UserEmail:      "seller@merchant.com",
+		PaymentMethod:  definitions.PaymentMethodPos,
+		TerminalModel:  "N86",
+		TerminalSerial: "N860W000000",
+		Reference:      "d9b10690-981d-494d-bcb0-66a1dacab51d",
+		Description:    "Test Purchase",
+		Payer: &definitions.IntegrationPayer{
+			Email:       "customer@example.com",
+			PhoneNumber: "3100000000",
+			Document: &definitions.IntegrationPayerDocument{
+				DocumentType:   definitions.DocumentTypeCedula,
+				DocumentNumber: "1010140000",
+			},
+		},
+	}
+}

--- a/src/sdk/create_payment_for_integrations_api.go
+++ b/src/sdk/create_payment_for_integrations_api.go
@@ -1,0 +1,22 @@
+package sdk
+
+import (
+	"context"
+
+	"github.com/PChaparro/bold-co-sdk/src/definitions"
+)
+
+// CreatePaymentForIntegrationsAPI sends a request to create a payment using the integrations API.
+// It accepts a context and a CreatePaymentForIntegrationsAPIRequest with the necessary parameters.
+// Returns the API response with the payment details or an error.
+func (client *BoldClient) CreatePaymentForIntegrationsAPI(ctx context.Context, req definitions.CreatePaymentForIntegrationsAPIRequest) (*definitions.CreatePaymentForIntegrationsAPIResponse, error) {
+	return sendPOSTRequest[definitions.CreatePaymentForIntegrationsAPIResponse](
+		client,
+		ctx,
+		RequestParams{
+			Endpoint: "/payments/app-checkout",
+			Action:   "create payment for integrations API",
+			Body:     req,
+		},
+	)
+}

--- a/src/sdk/create_payment_for_integrations_api_test.go
+++ b/src/sdk/create_payment_for_integrations_api_test.go
@@ -1,0 +1,44 @@
+package sdk
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PChaparro/bold-co-sdk/src/internal/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreatePaymentForIntegrationsAPI(t *testing.T) {
+	// Get API key from environment variable
+	apiKey := os.Getenv("BOLD_API_KEY")
+	if apiKey == "" {
+		t.Skip("BOLD_API_KEY environment variable not set")
+	}
+
+	// Initialize the client
+	client := NewClient(ClientConfig{
+		ApiKey: apiKey,
+	})
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	t.Run("expecting terminal not available error", func(t *testing.T) {
+		// Create a payment request using our helper
+		req := tests.GetPayloadToCreateValidPaymentForIntegrationsAPI()
+
+		// Make the request
+		response, err := client.CreatePaymentForIntegrationsAPI(ctx, *req)
+
+		// We expect an error about terminal not available
+		require.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "Terminal no disponible"),
+			"Expected error to contain 'Terminal no disponible', got: %v", err)
+		assert.Nil(t, response)
+	})
+}


### PR DESCRIPTION
## Change Description

This pull request implements a new method to create payments using the Integrations API. The method enables initiating a payment transaction through a payment terminal, as defined in the Bold API.

## API Documentation

- [Creación de pagos mediante API](https://developers.bold.co/api-integrations/integration#6-creaci%C3%B3n-de-pagos-mediante-api)

## Testing

Due to the lack of a physical payment terminal, full end-to-end testing was not possible. However, a test was added to validate the request structure and ensure the SDK sends a properly formatted body. The request was correctly rejected by the API with an expected error indicating that the terminal could not be found — confirming that the payload structure is valid, even though no terminal exists in the current environment.

## Checklist

- [x] I have read and followed the contribution guidelines described in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.

## Additional Context

While real payment processing could not be tested, the request matches the structure and expectations defined in the API documentation. 

## Related Issues

Not applicable.
